### PR TITLE
Hide Quest button from the «Direct Messages» page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ at Discord, mostly aimed at reducing visual clutter and improving performance.
 
 ## List of changes
 
-- The Nitro and Shop links are hidden from the `Direct Messages` page.
+- The Nitro, Shop and Quest links are hidden from the `Direct Messages` page.
 - Animated avatar decorations and animated profile effects will no longer appear either in profiles
   or in the channels.
 - "Discover" and "Download App" buttons are gone from the sidebar.

--- a/tolerable.js
+++ b/tolerable.js
@@ -29,6 +29,7 @@ loader("div#app-mount").then((_) => {
   stylesheet.innerText = `
 
   /* Hide Nitro and Shop buttons from the sidebar */
+  li[role^="listitem"]:has(div > a[href*="/quest-home"]),
   li[role^="listitem"]:has(div > a[href*="/store"]),
   li[role^="listitem"]:has(div > a[href*="/shop"]) {
     display: none;


### PR DESCRIPTION
This PR adds a filter which hides this awful button nobody ever asked for.

<img width="762" height="360" alt="imagem" src="https://github.com/user-attachments/assets/c80f57a2-f37b-4a1f-810e-0be1ba1af726" />

README was also updated to reflect this.